### PR TITLE
chore: reduce supply chain protection from 7 days to 1 day

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
       # Actually keep everything updated (if you remove this, keep the above ones).
       - dependency-type: "all"
     cooldown:
-      default-days: 7
+      default-days: 1
       exclude:
         - "brakeman"
 
@@ -27,7 +27,7 @@ updates:
       - dependency-name: "webpack"
         update-types: ["version-update:semver-major"]
     cooldown:
-      default-days: 7
+      default-days: 1
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-min-release-age=7
+min-release-age=1


### PR DESCRIPTION
Reduces the supply chain attack protection window from 7 days to 1 day:

- `.npmrc`: `min-release-age=7` → `min-release-age=1`
- `.github/dependabot.yml`: `default-days: 7` → `default-days: 1`

The 7-day window was overly cautious in practice.