### PR TITLE
chore: reduce supply chain protection from 7 days to 1 day

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
       # Actually keep everything updated (if you remove this, keep the above ones).
       - dependency-type: "all"
     cooldown:
-      default-days: 7
+      default-days: 1
       exclude:
         - "brakeman"
 
@@ -27,7 +27,7 @@ updates:
       - dependency-name: "webpack"
         update-types: ["version-update:semver-major"]
     cooldown:
-      default-days: 7
+      default-days: 1
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-min-release-age=7
+min-release-age=1

--- a/package-lock.json
+++ b/package-lock.json
@@ -5450,7 +5450,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -10795,11 +10794,12 @@
       "license": "MIT"
     },
     "node_modules/resolve": {
-      "version": "1.22.11",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
-      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
       "license": "MIT",
       "dependencies": {
+        "es-errors": "^1.3.0",
         "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"


### PR DESCRIPTION
Reduces the supply chain attack protection window from 7 days to 1 day:

- `.npmrc`: `min-release-age=7` -> `min-release-age=1`
- `.github/dependabot.yml`: `default-days: 7` -> `default-days: 1`

The 7-day window was overly cautious in practice.