### PR TITLE
chore: bump Ruby 3.4.7 → 3.4.9

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-ruby 3.4.7
+ruby 3.4.9
 nodejs 24.14.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -366,7 +366,7 @@ DEPENDENCIES
   web-console
 
 RUBY VERSION
-   ruby 3.4.7p58
+   ruby 3.4.9p82
 
 BUNDLED WITH
    2.7.2


### PR DESCRIPTION
Bumps Ruby from 3.4.7 to 3.4.9 (latest patch).

### Changes
- `.tool-versions`: ruby 3.4.7 → 3.4.9
- `Gemfile.lock`: updated RUBY VERSION

[Ruby 3.4.9 release notes](https://www.ruby-lang.org/en/news/2026/03/11/ruby-3-4-9-released/)