### PR TITLE
Claude Maintenance biannual 29.04.26

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 ruby 3.4.9
-nodejs 24.14.1
+nodejs 24.15.0

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 ruby file: ".tool-versions"
 
 gem "pry"
-gem "puma", "~> 7.2"
+gem "puma", "~> 8.0"
 gem "rack-attack"
 gem "rails", "~> 8.1.1"
 gem "redis"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,7 +128,7 @@ GEM
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     io-console (0.8.2)
-    irb (1.17.0)
+    irb (1.18.0)
       pp (>= 0.6.0)
       prism (>= 1.3.0)
       rdoc (>= 4.0.0)
@@ -163,9 +163,9 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.5)
-    nokogiri (1.19.2-arm64-darwin)
+    nokogiri (1.19.3-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.19.2-x86_64-linux-gnu)
+    nokogiri (1.19.3-x86_64-linux-gnu)
       racc (~> 1.4)
     package_json (0.2.0)
     parallel (2.1.0)
@@ -339,6 +339,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-25
   x86_64-linux
 
 DEPENDENCIES

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -185,7 +185,7 @@ GEM
       date
       stringio
     public_suffix (7.0.5)
-    puma (7.2.0)
+    puma (8.0.1)
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.2.6)
@@ -350,7 +350,7 @@ DEPENDENCIES
   erb_lint
   pivotal_git_scripts
   pry
-  puma (~> 7.2)
+  puma (~> 8.0)
   rack-attack
   rack-mini-profiler (~> 4.0)
   rails (~> 8.1.1)

--- a/README.md
+++ b/README.md
@@ -44,9 +44,12 @@ Since the password is in the hash-part of the URL it is never sent to the server
 
 You must have the following installed and available on your machine:
 
-- **Ruby 2.7.x**
-- **Node JS 18.x**
+- **Ruby 3.4.x**
+- **Node JS 24.x**
 - **Redis**
+
+Versions are pinned in [`.tool-versions`](.tool-versions); using
+[asdf](https://asdf-vm.com/) (or any compatible version manager) is recommended.
 
 # Developing
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -17,6 +17,7 @@ const compat = new FlatCompat({
 export default defineConfig([
   globalIgnores(["**/coverage", "public/packs*", "**/node_modules"]),
   {
+    files: ["**/*.{js,jsx,mjs,cjs}"],
     extends: compat.extends("eslint:recommended", "prettier"),
 
     plugins: {
@@ -52,6 +53,11 @@ export default defineConfig([
       ],
       "react/jsx-uses-vars": "warn",
       "react/jsx-uses-react": "warn",
+
+      "no-unused-vars": [
+        "error",
+        { argsIgnorePattern: "^_", varsIgnorePattern: "^_", caughtErrorsIgnorePattern: "^_" },
+      ],
 
       // Don't allow console.log
       "no-console": ["error"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -10046,9 +10046,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
-      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "funding": [
         {
           "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "overrides": {
     "glob": "^7.2.0",
     "resolve": "^1.22.2",
-    "postcss": "^8.5.9"
+    "postcss": "^8.5.10"
   },
   "browserslist": [
     "defaults"


### PR DESCRIPTION
## Maintenance window — 2026 H1

Autonomous biannual maintenance window for [Asana 2026 H1 - Abtion secret maintenance](https://app.asana.com/1/164791055906616/project/1102088177377811/task/1211694467939287). One commit per maintenance subtask.

### Changes (6 commits)

| # | Subtask | Change |
|---|---|---|
| 1 | Resolve dependabot security advisory | Bump `overrides.postcss` to `^8.5.10` (postcss XSS, [GHSA-qx2v-qp2m-jg93](https://github.com/advisories/GHSA-qx2v-qp2m-jg93)) |
| 2 | Bump minor/patch gems | `irb 1.17.0 → 1.18.0`, `nokogiri 1.19.2 → 1.19.3` |
| 3 | Fix relevant warnings | `eslint.config.mjs` had no `files` selector → `.jsx` files were silently skipped on CI; add selector (`{js,jsx,mjs,cjs}`) and recognize `_`-prefixed unused vars convention |
| 4 | Bump runtime patch | `Node 24.14.1 → 24.15.0` (.tool-versions) |
| 5 | Make project easy for new devs | README claimed Ruby 2.7 / Node 18 (out by 2 majors of each); refresh and point to `.tool-versions` |
| 6 | Bump major (assessed safe) | `puma 7.2 → 8.0.1` (cf. #2891) |

### Reported but not changed

- **`webpack-cli 6 → 7` (PR #2775)**: Initial bump was reverted after PR review surfaced that shakapacker 9.6.1's peer range is `^4.9.2 || ^5.0.0 || ^6.0.0` — v7 is not declared compatible. `cross-spawn@7.0.6` (the patched version) is already deduped via eslint and execa, so there's no security upside either. webpack-cli 7 should land alongside shakapacker 10 in a future window.
- **`npm audit fix`**: only options are breaking downgrades (`shakapacker 6.2.1`, `node-sass-glob-importer 3.0.2`, `webpack-dev-server 1.16.5`). Skipping. Remaining advisories: `path-to-regexp` (high, transitive), `sockjs/uuid` (moderate, dev-only via `webpack-dev-server`), and the `node-sass-magic-importer/css-node-extract/css-selector-extract` chain (moderate, deep transitive). Need a dedicated investigation window — not safe in this one.
- **Runtime majors**: Ruby `4.0.x` is out, Node 25 is current — both leave Ruby 3.4 (EOL 2028-03) and Node 24 (EOL 2028-04) supported for years. No major bump.
- **Rails**: `~> 8.1.1` already resolves to `8.1.3` (latest patch). No-op.
- **Bundler**: lockfile pins `2.7.2`. Bundler `4.0.x` is a major; deferred for a dedicated window.
- **Project board** ([Asana](https://app.asana.com/0/1200290320241129/board)): no open bugs in Backlog.
- **Deferred major dependabot PRs** (each needs its own assessment): eslint 9→10 (#2877), stylelint 16→17 (#2864), stylelint-config-sass-guidelines 12→13 (#2887), shakapacker 9→10 (#2822/#2823).
- **AppSignal / Heroku addons**: no credentials in this run; deferred.

### Self-attestation

- [x] I, the autonomous agent performing this maintenance window, ran the test suite and confirmed that all tests pass.
- [x] I, the autonomous agent performing this maintenance window, ran the type check and linters of this project, and confirmed that all of them are green.
- [x] I, the autonomous agent performing this maintenance window, monitored the CI of my PR and confirmed it is green.
- [x] I, the autonomous agent performing this maintenance window, conducted a careful, analytical assessment of all the comments in the PR, fixed them, and/or replied with the hash of the fixed commit or explained why I didn't fix them.
- [x] I, the autonomous agent performing this maintenance window, made a final pass over the diff between main and my PR and confirmed that my changes are safe and contribute to the PR's intended outcome.
- [x] I, the autonomous agent performing this maintenance window, can guarantee that this PR is mergeable without human intervention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)