### PR TITLE
Bump shakapacker 9.6.1 → 10.0.0 and webpack-cli 6.0.1 → 7.0.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem "puma", "~> 8.0"
 gem "rack-attack"
 gem "rails", "~> 8.1.1"
 gem "redis"
-gem "shakapacker", "9.6.1"
+gem "shakapacker", "10.0.0"
 gem "tzinfo-data", platforms: [:windows, :jruby]
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -300,7 +300,7 @@ GEM
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
     semantic_range (3.1.1)
-    shakapacker (9.6.1)
+    shakapacker (10.0.0)
       activesupport (>= 5.2)
       package_json
       rack-proxy (>= 0.6.1)
@@ -361,7 +361,7 @@ DEPENDENCIES
   rubocop-rails
   rubocop-rspec
   selenium-webdriver (>= 4.11)
-  shakapacker (= 9.6.1)
+  shakapacker (= 10.0.0)
   simplecov
   tzinfo-data
   web-console

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,12 +19,12 @@
         "react-dom": "^19.2.5",
         "sass": "^1.94.2",
         "sass-loader": "^16.0.7",
-        "shakapacker": "9.6.1",
+        "shakapacker": "10.0.0",
         "swc-loader": "^0.2.7",
         "terser-webpack-plugin": "^5.4.0",
         "webpack": "^5.106.1",
         "webpack-assets-manifest": "^6.5.1",
-        "webpack-cli": "^6.0.1",
+        "webpack-cli": "^7.0.2",
         "webpack-merge": "^6.0.1"
       },
       "devDependencies": {
@@ -748,9 +748,9 @@
       }
     },
     "node_modules/@discoveryjs/json-ext": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.6.3.tgz",
-      "integrity": "sha512-4B4OijXeVNOPZlYA2oEwWOTkzyltLao+xbotHQeqN++Rv27Y6s818+n2Qkp8q+Fxhn0t/5lA5X1Mxktud8eayQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-1.0.0.tgz",
+      "integrity": "sha512-dDlz3W405VMFO4w5kIP9DOmELBcvFQGmLoKSdIRstBDubKFYwaNHV1NnlzMCQpXQFGWVALmeMORAuiLx18AvZQ==",
       "license": "MIT",
       "engines": {
         "node": ">=14.17.0"
@@ -3482,50 +3482,6 @@
         "@xtuc/long": "4.2.2"
       }
     },
-    "node_modules/@webpack-cli/configtest": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-3.0.1.tgz",
-      "integrity": "sha512-u8d0pJ5YFgneF/GuvEiDA61Tf1VDomHHYMjv/wc9XzYj7nopltpG96nXN5dJRstxZhcNpV1g+nT6CydO7pHbjA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.12.0"
-      },
-      "peerDependencies": {
-        "webpack": "^5.82.0",
-        "webpack-cli": "6.x.x"
-      }
-    },
-    "node_modules/@webpack-cli/info": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-3.0.1.tgz",
-      "integrity": "sha512-coEmDzc2u/ffMvuW9aCjoRzNSPDl/XLuhPdlFRpT9tZHmJ/039az33CE7uH+8s0uL1j5ZNtfdv0HkfaKRBGJsQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.12.0"
-      },
-      "peerDependencies": {
-        "webpack": "^5.82.0",
-        "webpack-cli": "6.x.x"
-      }
-    },
-    "node_modules/@webpack-cli/serve": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-3.0.1.tgz",
-      "integrity": "sha512-sbgw03xQaCLiT6gcY/6u3qBDn01CWw/nbaXl3gTdTFuJJ75Gffv3E3DBpgvY2fkkrdS1fpjaXNOmJlnbtKauKg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.12.0"
-      },
-      "peerDependencies": {
-        "webpack": "^5.82.0",
-        "webpack-cli": "6.x.x"
-      },
-      "peerDependenciesMeta": {
-        "webpack-dev-server": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -4599,6 +4555,7 @@
       "version": "2.0.20",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/commander": {
@@ -9778,6 +9735,29 @@
         "node": ">=6"
       }
     },
+    "node_modules/pack-config-diff": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/pack-config-diff/-/pack-config-diff-0.1.0.tgz",
+      "integrity": "sha512-gx60G4pnT4GFQ7WECdf7SCq9vdsvBhodLXXzwisy37/t0zkAZ3hMgLCdOGivudF1l0gcLZhIWVYreS89be15QA==",
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^4.1.0"
+      },
+      "bin": {
+        "pack-config-diff": "bin/pack-config-diff"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "ts-node": ">=10"
+      },
+      "peerDependenciesMeta": {
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/param-case": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
@@ -11193,12 +11173,13 @@
       "license": "ISC"
     },
     "node_modules/shakapacker": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/shakapacker/-/shakapacker-9.6.1.tgz",
-      "integrity": "sha512-xE1RAm6c1C6o1Erj+8Iih/WqmauKpcGUiZ2t8NJRBlKmOypvWpyk+h2DQ3u02ii3aiOYlDDSboJMk/yzmaIOPA==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/shakapacker/-/shakapacker-10.0.0.tgz",
+      "integrity": "sha512-bLKU/xGxIpC/oXvTBRLnpH6bjVK/wyYeWiwE35zd3xxbcg6WfbbQxls0L/AmO8p560RR2PgfR3QtHb7klBmu0A==",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.1.0",
+        "pack-config-diff": "^0.1.0",
         "path-complete-extname": "^1.0.0",
         "webpack-merge": "^5.8.0",
         "yargs": "^17.7.2"
@@ -11212,8 +11193,8 @@
         "@babel/plugin-transform-runtime": "^7.17.0",
         "@babel/preset-env": "^7.16.11",
         "@babel/runtime": "^7.17.9",
-        "@rspack/cli": "^1.0.0",
-        "@rspack/core": "^1.0.0",
+        "@rspack/cli": "^1.0.0 || ^2.0.0-0",
+        "@rspack/core": "^1.0.0 || ^2.0.0-0",
         "@rspack/plugin-react-refresh": "^1.0.0",
         "@swc/core": "^1.3.0",
         "@types/babel__core": "^7.0.0",
@@ -11229,10 +11210,10 @@
         "sass-loader": "^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0",
         "swc-loader": "^0.1.15 || ^0.2.0",
         "terser-webpack-plugin": "^5.3.1",
-        "webpack": "^5.76.0",
+        "webpack": "^5.101.0",
         "webpack-assets-manifest": "^5.0.6 || ^6.0.0",
-        "webpack-cli": "^4.9.2 || ^5.0.0 || ^6.0.0",
-        "webpack-dev-server": "^4.15.2 || ^5.2.2",
+        "webpack-cli": "^4.9.2 || ^5.0.0 || ^6.0.0 || ^7.0.0",
+        "webpack-dev-server": "^5.2.2",
         "webpack-subresource-integrity": "^5.1.0"
       },
       "peerDependenciesMeta": {
@@ -12922,18 +12903,14 @@
       }
     },
     "node_modules/webpack-cli": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-6.0.1.tgz",
-      "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-7.0.2.tgz",
+      "integrity": "sha512-dB0R4T+C/8YuvM+fabdvil6QE44/ChDXikV5lOOkrUeCkW5hTJv2pGLE3keh+D5hjYw8icBaJkZzpFoaHV4T+g==",
       "license": "MIT",
       "dependencies": {
-        "@discoveryjs/json-ext": "^0.6.1",
-        "@webpack-cli/configtest": "^3.0.1",
-        "@webpack-cli/info": "^3.0.1",
-        "@webpack-cli/serve": "^3.0.1",
-        "colorette": "^2.0.14",
-        "commander": "^12.1.0",
-        "cross-spawn": "^7.0.3",
+        "@discoveryjs/json-ext": "^1.0.0",
+        "commander": "^14.0.3",
+        "cross-spawn": "^7.0.6",
         "envinfo": "^7.14.0",
         "fastest-levenshtein": "^1.0.12",
         "import-local": "^3.0.2",
@@ -12945,14 +12922,16 @@
         "webpack-cli": "bin/cli.js"
       },
       "engines": {
-        "node": ">=18.12.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       },
       "peerDependencies": {
-        "webpack": "^5.82.0"
+        "webpack": "^5.101.0",
+        "webpack-bundle-analyzer": "^4.0.0 || ^5.0.0",
+        "webpack-dev-server": "^5.0.0"
       },
       "peerDependenciesMeta": {
         "webpack-bundle-analyzer": {
@@ -12964,12 +12943,12 @@
       }
     },
     "node_modules/webpack-cli/node_modules/commander": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/webpack-dev-middleware": {

--- a/package.json
+++ b/package.json
@@ -17,12 +17,12 @@
     "react-dom": "^19.2.5",
     "sass": "^1.94.2",
     "sass-loader": "^16.0.7",
-    "shakapacker": "9.6.1",
+    "shakapacker": "10.0.0",
     "swc-loader": "^0.2.7",
     "terser-webpack-plugin": "^5.4.0",
     "webpack": "^5.106.1",
     "webpack-assets-manifest": "^6.5.1",
-    "webpack-cli": "^6.0.1",
+    "webpack-cli": "^7.0.2",
     "webpack-merge": "^6.0.1"
   },
   "engines": {


### PR DESCRIPTION
## What

Combined bump of three coupled dependencies into a single PR:
- `shakapacker` (gem) 9.6.1 → 10.0.0
- `shakapacker` (npm) 9.6.1 → 10.0.0
- `webpack-cli` (npm) ^6.0.1 → ^7.0.2

Supersedes the three Dependabot PRs that couldn't land independently:
- #2775 webpack-cli 6 → 7 (blocked: violated shakapacker 9.6.1's peer range)
- #2822 shakapacker 9 → 10 (bundler)
- #2823 shakapacker 9 → 10 (npm)

## Why combined?

`shakapacker` requires the gem and npm package versions to match exactly, and shakapacker 9.6.1's `peerDependencies.webpack-cli` is `^4.9.2 || ^5.0.0 || ^6.0.0` — so webpack-cli 7 only becomes valid once shakapacker 10 (which expands the peer range to include `^7.0.0`) is in.

## Breaking changes verified

Per [shakapacker 10.0.0 release notes](https://github.com/shakacode/shakapacker/releases/tag/v10.0.0):
- ✅ `webpack-dev-server >= 5.2.2` — we have `^5.2.3`
- ✅ `webpack >= 5.101.0` — we have `^5.106.1`
- ✅ `setup_middlewares` (vs. legacy `on_before_setup_middleware`/`on_after_setup_middleware`) — this app has no custom middleware hooks

## Validation

Local: rspec (17/17, 100% coverage), rubocop, brakeman, erb-lint, jest (9/9), eslint, stylelint, prettier — all green. `bin/shakapacker` compiles cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)