### PR TITLE
test(secrets): cover unused_key retry and X-Api-Version routing

### DIFF
--- a/spec/controllers/api/v1/secrets_controller_spec.rb
+++ b/spec/controllers/api/v1/secrets_controller_spec.rb
@@ -5,6 +5,28 @@ require "tempfile"
 
 RSpec.describe(Api::V1::SecretsController) do
   describe "POST /" do
+    describe "key generation" do
+      let(:key_length) { Api::V1::SecretsController::KEY_LENGTH }
+      let(:colliding_key) { "a" * key_length }
+      let(:fresh_key) { "b" * key_length }
+
+      it "regenerates the key when the first candidate already exists in the cache" do
+        Rails.cache.write("secret-#{colliding_key}", "occupant")
+        allow(SecureRandom).to receive(:urlsafe_base64).and_return(colliding_key, fresh_key)
+
+        file = Tempfile.new("encryped-secret")
+        file.write("payload")
+        file.close
+
+        post :create, params: { secret: fixture_file_upload(file.path) }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body).to eq(fresh_key)
+        expect(SecureRandom).to have_received(:urlsafe_base64).twice
+        expect(Rails.cache.read("secret-#{colliding_key}")).to eq("occupant")
+      end
+    end
+
     describe "file size limit" do
       let(:max_size) { ENV.fetch("MAX_ENCRYPTED_SECRET_SIZE").to_i }
 

--- a/spec/requests/api/v1/secrets_spec.rb
+++ b/spec/requests/api/v1/secrets_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Api::V1::Secrets", type: :request do
+  describe "X-Api-Version routing constraint" do
+    let(:key) { "known-key" }
+
+    before { Rails.cache.write("secret-#{key}", "ciphertext-bytes") }
+
+    context "when X-Api-Version: v1 is sent" do
+      it "routes GET /api/secrets/:id to the v1 API and returns the payload" do
+        get "/api/secrets/#{key}", headers: { "X-Api-Version" => "v1" }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to eq("ciphertext-bytes")
+      end
+    end
+
+    context "when the X-Api-Version header is missing" do
+      it "falls through to the catch-all secrets#show (renders the React frontend)" do
+        get "/api/secrets/#{key}"
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include('data-react-component="SecretShow"')
+      end
+    end
+
+    context "when the X-Api-Version header doesn't match" do
+      it "falls through to the catch-all secrets#show (renders the React frontend)" do
+        get "/api/secrets/#{key}", headers: { "X-Api-Version" => "v2" }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include('data-react-component="SecretShow"')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Two small spec additions to lock in behaviour that was implicitly relied on but not tested.

## Commits

- **\`unused_key\` retry on collision** (\`spec/controllers/api/v1/secrets_controller_spec.rb\`)
  The controller's \`unused_key\` regenerates when \`Rails.cache.exist?\` returns true. Line coverage was already 100% but the retry branch was never exercised. Stubs \`SecureRandom.urlsafe_base64\` to return a colliding-then-fresh pair and asserts the loop iterates.

- **\`X-Api-Version\` routing constraint at the request level** (\`spec/requests/api/v1/secrets_spec.rb\`)
  \`Constraints::ApiVersion#matches?\` is unit-tested, but the routing wiring isn't. Without \`X-Api-Version: v1\`, requests don't 404 — they fall through to \`match "*key", to: "secrets#show"\` and render the React frontend. Three specs pin: header matches → API payload; header missing → catch-all; header mismatched → catch-all.

## Validation

23/23 specs pass, 100% line coverage retained, rubocop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)