### PR TITLE
Enable shakapacker ensure_consistent_versioning

### DIFF
--- a/config/shakapacker.yml
+++ b/config/shakapacker.yml
@@ -11,6 +11,9 @@ default: &default
   cache_path: tmp/shakapacker
   webpack_compile_output: true
 
+  # Prevents dependabot - and devs - from updating either shakapacker npms or gems independently
+  ensure_consistent_versioning: true
+
   # Additional paths webpack should look up modules
   # ['app/assets', 'engine/foo/app/assets']
   additional_paths: []


### PR DESCRIPTION
Adds `ensure_consistent_versioning: true` to `config/shakapacker.yml`.

Keeps the shakapacker gem and npm package locked to the same version, preventing dependabot (or devs) from bumping one without the other and producing a broken build.